### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -106,7 +106,7 @@ function ApplyLayout() {
 }
 
 function OpenDOI(DOI) {
-	window.open('http://dx.doi.org/' + $(DOI).text(), '_blank');
+	window.open('https://doi.org/' + $(DOI).text(), '_blank');
 }
 
 function OpenURL(URL) {

--- a/themes/skgadi-w3/static/js/script.js
+++ b/themes/skgadi-w3/static/js/script.js
@@ -106,7 +106,7 @@ function ApplyLayout() {
 }
 
 function OpenDOI(DOI) {
-	window.open('http://dx.doi.org/' + $(DOI).text(), '_blank');
+	window.open('https://doi.org/' + $(DOI).text(), '_blank');
 }
 
 function OpenURL(URL) {


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers!